### PR TITLE
ignore empty message from stdin

### DIFF
--- a/alerter/AppDelegate.m
+++ b/alerter/AppDelegate.m
@@ -170,6 +170,9 @@ isMavericks()
     if (message == nil && !isatty(STDIN_FILENO)) {
         NSData *inputData = [NSData dataWithData:[[NSFileHandle fileHandleWithStandardInput] readDataToEndOfFile]];
         message = [[NSString alloc] initWithData:inputData encoding:NSUTF8StringEncoding];
+        if ([message length] == 0) {
+            message = nil;
+        }
     }
     
     if (message == nil && remove == nil && list == nil) {


### PR DESCRIPTION
Without this change `alerter -remove XYZ` when executed with non tty stdin (for example by launchd, can be imitated in terminal using `cat | alerter -remove XYZ`) creates a blank notification.