### PR TITLE
refactor: use the new NotificationFramework for pushing notifications

### DIFF
--- a/alerter/AppDelegate.h
+++ b/alerter/AppDelegate.h
@@ -1,5 +1,6 @@
 #import <Cocoa/Cocoa.h>
+#import <UserNotifications/UserNotifications.h>
 
-@interface AppDelegate : NSObject <NSApplicationDelegate, NSUserNotificationCenterDelegate>
+@interface AppDelegate : NSObject <NSApplicationDelegate, UNUserNotificationCenterDelegate>
 -(void)bye;
 @end

--- a/alerter/main.m
+++ b/alerter/main.m
@@ -1,13 +1,4 @@
-//
-//  main.m
-//  alerter
-//
-//  Created by Valere JEANTET on 18/12/2015.
-//  All the works are available under the MIT license.
-//
-
 #import "AppDelegate.h"
-
 
 AppDelegate * appDelegate ;
 
@@ -32,4 +23,3 @@ int main(int argc, char *argv[])
     
     return EXIT_SUCCESS;
 }
-


### PR DESCRIPTION
Fixes #52

Replace `NSUserNotification` API with `UserNotifications.frameworks` API.

* Import `UserNotifications/UserNotifications.h` in `alerter/AppDelegate.h` and `alerter/AppDelegate.m`.
* Conform to `UNUserNotificationCenterDelegate` instead of `NSUserNotificationCenterDelegate` in `alerter/AppDelegate.h`.
* Replace `NSUserNotification` with `UNNotificationRequest` for creating notifications in `alerter/AppDelegate.m`.
* Replace `NSUserNotificationCenter` delegate methods with `UNUserNotificationCenter` delegate methods in `alerter/AppDelegate.m`.
* Update methods to use `UNUserNotificationCenter` for managing notifications in `alerter/AppDelegate.m`.
* Remove references to `NSUserNotification` in `alerter/main.m`.

