### PR TITLE
Fix: --app-icon breaking --timeout auto-dismissal

### DIFF
--- a/Sources/Alerter/NotificationManager.swift
+++ b/Sources/Alerter/NotificationManager.swift
@@ -39,6 +39,7 @@ class NotificationManager: NSObject, NSUserNotificationCenterDelegate {
         notification.title = config.title
         notification.subtitle = config.subtitle
         notification.informativeText = config.message
+        notification.identifier = config.uuid
 
         // Store config info in userInfo for callbacks
         var userInfo: [String: String] = ["uuid": config.uuid, "timeout": "\(config.timeout)"]


### PR DESCRIPTION
**AI Disclosure**: I used Claude Code to investigate the issue. I evaluated the proposed root cause for plausibility, and then I served as the interactive QA. -- I checked for rules in the Code of Conduct (and looked for CONTRIBUTING.md), but I didn't find rules against it. -- I, Frederic Barthelemy (@fbartho), stand by this code change as worth considering, but I understand if you'd rather I not participate in this way.

Fixes vjeantet/alerter#62

## Summary

Fixes #62 — `--app-icon` prevents `--timeout` from auto-dismissing the notification banner.

**Root cause:** When `--app-icon` sets the private `_identityImage` property via KVC, it alters the notification's internal state enough that `removeDeliveredNotification(_:)` silently fails to match and remove the notification.

**Fix:** Set `notification.identifier = config.uuid` before delivery. This gives `NSUserNotificationCenter` an explicit string identifier for matching, bypassing the broken object-identity matching.

One-line change in `NotificationManager.swift`.

## Testing

Before fix:
```bash
# Banner stays on screen indefinitely after alerter exits
alerter --title "Test" --message "stuck" --timeout 5 \
  --app-icon /System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/GenericApplicationIcon.icns
```

After fix:
- Banner auto-dismisses after timeout ✓
- `--app-icon` with URL works ✓
- `--app-icon` with local path works ✓
- `--content-image` still works ✓
- `--remove <group>` works on app-icon notifications ✓
- Notifications without `--app-icon` unaffected ✓

Tested on macOS 26.3 (Tahoe), Apple Silicon.
